### PR TITLE
Add plotting, model-tuning, add error bars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /Manifest.toml
 /docs/build/
 /examples/*.csv
+/examples/*.pdf

--- a/Project.toml
+++ b/Project.toml
@@ -8,11 +8,16 @@ CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
+Measurements = "eff96d63-e80a-5855-80a2-b1b0885c5ab7"
+ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 CSV = "0.8"
 Distributions = "0.25"
 DocStringExtensions = "0.8"
+Measurements = "2"
+ProgressMeter = "1"
 julia = "1.4"
 
 [extras]

--- a/examples/plot_outcomes.jl
+++ b/examples/plot_outcomes.jl
@@ -1,0 +1,50 @@
+using PyPlot: PyPlot, plt
+using Colors
+
+pnames = setdiff(sort(collect(keys(yielddat))), ["B", "CMB"])  # remove outdated programs
+psim = [progsim(p1, p2) for p1 in pnames, p2 in pnames]
+fig, ax = plt.subplots(1, 1; figsize=(3,3))
+ax.imshow(psim)
+ax.set_xticks(0:length(pnames)-1)
+ax.set_yticks(0:length(pnames)-1)
+ax.set_xticklabels(pnames; rotation="vertical")
+ax.set_yticklabels(pnames)
+fig.tight_layout()
+fig.savefig("program_similarity.pdf")
+
+
+cols = hex.(distinguishable_colors(length(pnames), [colorant"white"]; dropseed=true))
+fig, axs = plt.subplots(1, 2; figsize=(6,3))
+ax = axs[1]
+sel = [(od = offerdat[n]; od[1]/(od[1] + od[2])) for n in pnames]
+ax.bar(0:length(pnames)-1, 100*sel)
+ax.set_xticks(0:length(pnames)-1)
+ax.set_xticklabels(pnames; rotation="vertical")
+ax.set_ylabel("% admitted")
+ax = axs[2]
+len(::Type{NTuple{N,T}}) where {N,T} = N
+accepts = zeros(len(valtype(yielddat)), length(pnames))
+declines = zero(accepts)
+for (j, n) in enumerate(pnames)
+    yd = yielddat[n]
+    for (i, o) in enumerate(yd)
+        accepts[i,j] = o.naccepts
+        declines[i,j] = o.ndeclines
+    end
+end
+xc = [1/6, 3/6, 5/6]
+adnorm = sum(accepts; dims=1) + sum(declines; dims=1)
+lna = plt.plot(xc, 100*accepts ./ adnorm)
+lnd = plt.plot(xc, 100*declines ./ adnorm, "--")
+for lns in (lna, lnd)
+    for (ln,col) in zip(lns, cols)
+        ln.set_color("#"*lowercase(col))
+    end
+end
+ax.set_xticks(xc)
+ax.set_xticklabels(["Early", "Mid", "Late"])
+ax.set_xlabel("Time")
+ax.set_ylabel("% of offers")
+ax.legend(lna, pnames; fontsize="x-small", bbox_to_anchor=(1,1))
+fig.tight_layout()
+fig.savefig("program_similarity_data.pdf")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,75 +12,166 @@ function countby(list)
 end
 
 @testset "AdmissionsSimulation.jl" begin
-    program_history = Dict(ProgramKey("NS", 2021) => ProgramData(slots=15, napplicants=302, firstofferdate=Date("2021-01-13"), lastdecisiondate=Date("2021-04-15")),
-                           ProgramKey("CB", 2021) => ProgramData(slots=5,  napplicants=160, firstofferdate=Date("2021-01-6"),  lastdecisiondate=Date("2021-04-15")),
-    )
-    past_applicants = [(program="NS", rank=7, offerdate=Date("2021-01-13"), decidedate=Date("2021-03-26"), accept=true),
-                       (program="NS", rank=3, offerdate=Date("2021-01-13"), decidedate=Date("2021-04-15"), accept=false),
-                       (program="CB", rank=6, offerdate=Date("2021-03-25"), decidedate=Date("2021-04-15"), accept=true),
-    ]
-    past_applicants = [NormalizedApplicant(; app..., program_history) for app in past_applicants]
+    @testset "Matching and matriculation probability" begin
+        program_history = Dict(ProgramKey("NS", 2021) => ProgramData(slots=15, napplicants=302, firstofferdate=Date("2021-01-13"), lastdecisiondate=Date("2021-04-15")),
+                               ProgramKey("CB", 2021) => ProgramData(slots=5,  napplicants=160, firstofferdate=Date("2021-01-6"),  lastdecisiondate=Date("2021-04-15")),
+        )
+        past_applicants = [(program="NS", rank=7, offerdate=Date("2021-01-13"), decidedate=Date("2021-03-26"), accept=true),
+                           (program="NS", rank=3, offerdate=Date("2021-01-13"), decidedate=Date("2021-04-15"), accept=false),
+                           (program="CB", rank=6, offerdate=Date("2021-03-25"), decidedate=Date("2021-04-15"), accept=true),
+        ]
+        past_applicants = [NormalizedApplicant(; app..., program_history) for app in past_applicants]
 
-    applicant = NormalizedApplicant(; program="NS", rank=11, offerdate=Date("2021-01-13"), program_history)
+        applicant = NormalizedApplicant(; program="NS", rank=11, offerdate=Date("2021-01-13"), program_history)
 
-    # A match function that heavily weights normalized rank
-    fmatch = match_function(σr=0.01, σt=Inf, progsim=(a,b)->true)
-    like = @inferred(match_likelihood(fmatch, past_applicants, applicant, 0.0))
-    @test like[3] > like[1] > like[2]
-    @test matriculation_probability(like, past_applicants) > 0.95
-    clike = cumsum(like)
-    s = [select_applicant(clike, past_applicants) for i = 1:100]
-    sc = first.(sort(collect(pairs(countby(s))); by=last))
-    @test sc[end].program == "CB"    # best match is to rank 11/302 ≈ 6/160
-    @test sc[end-1].program == "NS" && sc[end-1].normrank == Float32(7/302)
+        # A match function that heavily weights normalized rank
+        fmatch = match_function(σr=0.01, σt=Inf, progsim=(a,b)->true)
+        like = @inferred(match_likelihood(fmatch, past_applicants, applicant, 0.0))
+        @test like[3] > like[1] > like[2]
+        @test matriculation_probability(like, past_applicants) > 0.95
+        clike = cumsum(like)
+        s = [select_applicant(clike, past_applicants) for i = 1:100]
+        sc = first.(sort(collect(pairs(countby(s))); by=last))
+        @test sc[end].program == "CB"    # best match is to rank 7/302 since it's closest to 6/160
+        @test sc[end-1].program == "NS" && sc[end-1].normrank == Float32(7/302)
 
-    # A match function that heavily weights offer date
-    fmatch = match_function(σr=Inf, σt=0.3, progsim=(a,b)->true)
-    like = match_likelihood(fmatch, past_applicants, applicant, 0.0)
-    @test like[1] == like[2] == 1
-    @test like[1] > like[3]
-    @test 0.48 < matriculation_probability(like, past_applicants) < 0.52
-
-    # Require program-specific matching
-    fmatch = match_function(σr=0.01, σt=Inf)
-    like = match_likelihood(fmatch, past_applicants, applicant, Date("2021-01-13"); program_history)
-    @test like[1] > like[2]
-    @test like[3] == 0
-
-    # Excluding applicants who had already decided at this point in the season
-    fmatch = match_function(σr=0.01, σt=Inf)
-    like = match_likelihood(fmatch, past_applicants, applicant, Date("2021-04-01"); program_history)
-    @test like[2] > 0
-    @test like[1] == like[3] == 0
-
-    # I/O, program data, program similarity
-    program_history = read_program_history(joinpath(@__DIR__, "data", "programdata.csv"))
-    new_applicants = [(program="NS", rank=7, offerdate=Date("2021-01-13")),
-                      (program="NS", rank=3, offerdate=Date("2021-01-13")),
-                      (program="CB", rank=6, offerdate=Date("2021-03-25")),
-    ]
-    new_applicants = [NormalizedApplicant(; app..., program_history) for app in new_applicants]
-    past_applicants = read_applicant_data(joinpath(@__DIR__, "data", "applicantdata.csv"); program_history)
-    # The data was set up to be symmetric except for date
-    od = offerdata(past_applicants, program_history)
-    @test od["NS"] == od["CB"] == (18, 160)
-    yd = yielddata(Outcome, past_applicants)
-    @test yd["NS"] == yd["CB"] == Outcome(9, 9)
-    yd = yielddata(Tuple{Outcome,Outcome,Outcome}, past_applicants)
-    @test yd["NS"] == (Outcome(0,1), Outcome(1,1), Outcome(8,7))
-    @test yd["CB"] == (Outcome(1,0), Outcome(0,1), Outcome(8,8))
-    @test program_similarity("NS", "CB"; σsel=0.1, offerdata=od, yielddata=yd) == 1
-    y1 = [0, 1, 1, 1, 8, 7]; y1 = y1/sum(y1)
-    y2 = [1, 0, 0, 1, 8, 8]; y2 = y2/sum(y2)
-    @test program_similarity("NS", "CB"; σyield=0.1, offerdata=od, yielddata=yd) ≈ exp(-sum((y1-y2).^2)/(0.02))
-    fsim = cached_similarity(0.1, 0.1; offerdata=od, yielddata=yd)
-    @test fsim("NS", "NS") == fsim("CB", "CB") == 1
-    @test fsim("NS", "CB") ≈ exp(-sum((y1-y2).^2)/(0.02))
-
-    fmatch = match_function(σr=0.05, σt=0.5, progsim=fsim)
-    pmatric = map(new_applicants) do applicant
+        # A match function that heavily weights offer date
+        fmatch = match_function(σr=Inf, σt=0.3, progsim=(a,b)->true)
         like = match_likelihood(fmatch, past_applicants, applicant, 0.0)
-        matriculation_probability(like, past_applicants)
+        @test like[1] == like[2] == 1
+        @test like[1] > like[3]
+        @test 0.48 < matriculation_probability(like, past_applicants) < 0.52
+
+        # Require program-specific matching
+        fmatch = match_function(σr=0.01, σt=Inf)   # `progsim` default returns `a == b`
+        like = match_likelihood(fmatch, past_applicants, applicant, Date("2021-01-13"); program_history)
+        @test like[1] > like[2]
+        @test like[3] == 0
+
+        # Excluding applicants who had already decided at this point in the season
+        fmatch = match_function(σr=0.01, σt=Inf)
+        like = match_likelihood(fmatch, past_applicants, applicant, Date("2021-04-01"); program_history)
+        @test like[2] > 0
+        @test like[1] == like[3] == 0
     end
-    @test all(x -> 0 <= x <= 1, pmatric)
+
+    @testset "Program similarity from program data" begin
+        offerdat = Dict("CB" => (4, 100), "NS" => (5, 100))
+        yielddat = Dict("CB" => (Outcome(0, 2), Outcome(2, 0)), "NS" => (Outcome(1, 1), Outcome(2, 1)))
+        @test program_similarity("CB", "CB"; σsel=1e-6, σyield=1e-6, offerdata=offerdat, yielddata=yielddat) == 1
+        @test program_similarity("CB", "NS"; σsel=1e-6, σyield=1e-6, offerdata=offerdat, yielddata=yielddat) == 0
+        @test program_similarity("CB", "NS"; σsel=Inf,  σyield=Inf,  offerdata=offerdat, yielddata=yielddat) == 1
+        @test program_similarity("CB", "NS"; σsel=0.01, σyield=Inf,  offerdata=offerdat, yielddata=yielddat) ≈ exp(-1/2)
+        @test program_similarity("CB", "NS"; σsel=Inf,  σyield=sqrt(0.18), offerdata=offerdat, yielddata=yielddat) ≈ exp(-1/2)
+    end
+
+    @testset "I/O, program data, program similarity" begin
+        io = IOBuffer()
+        print(io, Outcome(3, 5))
+        @test String(take!(io)) == "(d=3, a=5)"
+
+        program_history = read_program_history(joinpath(@__DIR__, "data", "programdata.csv"))
+        @test length(program_history) == 6
+        past_applicants = read_applicant_data(joinpath(@__DIR__, "data", "applicantdata.csv"); program_history)
+        @test length(past_applicants) == 36
+        new_applicants = [(program="NS", rank=7, offerdate=Date("2021-01-13")),
+                        (program="NS", rank=3, offerdate=Date("2021-01-13")),
+                        (program="CB", rank=6, offerdate=Date("2021-03-25")),
+        ]
+        new_applicants = [NormalizedApplicant(; app..., program_history) for app in new_applicants]
+        # The data were set up to be symmetric except for date
+        od = offerdata(past_applicants, program_history)
+        @test od["NS"] == od["CB"] == (18, 105)
+        yd = yielddata(Outcome, past_applicants)
+        @test yd["NS"] == yd["CB"] == Outcome(9, 9)
+        yd = yielddata(Tuple{Outcome,Outcome,Outcome}, past_applicants)
+        @test yd["NS"] == (Outcome(0,1), Outcome(1,1), Outcome(8,7))
+        @test yd["CB"] == (Outcome(1,0), Outcome(0,1), Outcome(8,8))
+        @test program_similarity("NS", "CB"; σsel=0.1, offerdata=od, yielddata=yd) == 1
+        y1 = [0, 1, 1, 1, 8, 7]; y1 = y1/sum(y1)
+        y2 = [1, 0, 0, 1, 8, 8]; y2 = y2/sum(y2)
+        @test program_similarity("NS", "CB"; σyield=0.1, offerdata=od, yielddata=yd) ≈ exp(-sum((y1-y2).^2)/(0.02))
+        fsim = cached_similarity(0.1, 0.1; offerdata=od, yielddata=yd)
+        @test fsim("NS", "NS") == fsim("CB", "CB") == 1
+        @test fsim("NS", "CB") ≈ exp(-sum((y1-y2).^2)/(0.02))
+
+        fmatch = match_function(σr=0.05, σt=0.5, progsim=fsim)
+        pmatric = map(new_applicants) do applicant
+            like = match_likelihood(fmatch, past_applicants, applicant, 0.0)
+            matriculation_probability(like, past_applicants)
+        end
+        @test all(x -> 0 <= x <= 1, pmatric)
+    end
+
+    @testset "Model training" begin
+        # Set up no overall difference among programs
+        program_history = Dict{ProgramKey,ProgramData}()
+        for prog in ("CB", "NS"), yr in 2019:2021
+            program_history[ProgramKey(prog, yr)] = ProgramData(slots=10, napplicants=100, firstofferdate=Date("$yr-01-13"), lastdecisiondate=Date("$yr-04-15"))
+        end
+        offerdates  = vec([Date("$yr-0$m-15") for yr in 2019:2021, m in 1:2])
+        decidedates = vec([Date("$yr-0$m-15") for yr in 2019:2021, m in 3:4])
+        σsels = σyields = σrs = σts = [0.01, Inf]
+        # Case 1: rank is meaningful, nothing else is
+        applicants = vec([NormalizedApplicant(; program=prog, rank=r, offerdate=od, decidedate=dd, accept=r>3, program_history) for prog in ("CB", "NS"), r in 1:6, od in offerdates, dd in decidedates])
+        np = net_probability(σsels, σyields, σrs, σts; applicants, program_history, rmatch_floor=0.25)
+        @test all(iszero, np[:,:,2,:])
+        @test isinf(np[1,1,1,1])
+        idx = argmax(np)
+        @test idx[3] == 1
+        @test idx[4] == 2
+        # Case 2: offer date is meaningful, nothing else is
+        applicants = vec([NormalizedApplicant(; program=prog, rank=r, offerdate=od, decidedate=dd, accept=month(od)==1, program_history) for prog in ("CB", "NS"), r in 1:6, od in offerdates, dd in decidedates])
+        np = net_probability(σsels, σyields, σrs, σts; applicants, program_history, rmatch_floor=0.25)
+        @test isinf(np[1,1,1,1])
+        idx = argmax(np)
+        @test idx[3] == 2
+        @test idx[4] == 1
+        # Case 3: program yield timing and rank are meaningful, nothing else is
+        progmonth = Dict("CB" => 3, "NS" => 4)
+        applicants = vec([NormalizedApplicant(; program=prog, rank=r, offerdate=od, decidedate=dd, accept=r>=progmonth[prog] && month(dd)==progmonth[prog], program_history) for prog in ("CB", "NS"), r in 1:6, od in offerdates, dd in decidedates])
+        np = net_probability(σsels, σyields, σrs, σts; applicants, program_history, rmatch_floor=0)
+        @test np[1,:,:,:] ≈ np[2,:,:,:]
+        @test np[:,:,:,1] ≈ np[:,:,:,2]
+        @test !(np[:,1,:,:] ≈ np[:,2,:,:])
+        @test !(np[:,:,1,:] ≈ np[:,:,2,:])
+        idx = argmax(np)
+        @test idx[2] == idx[3] == 1
+        # Case 4: program selectivity and rank are meaningful, nothing else is
+        progapps = Dict("CB" => 100, "NS" => 200)
+        for prog in ("CB", "NS"), yr in 2019:2021
+            program_history[ProgramKey(prog, yr)] = ProgramData(slots=10, napplicants=progapps[prog], firstofferdate=Date("$yr-01-13"), lastdecisiondate=Date("$yr-04-15"))
+        end
+        applicants = vec([NormalizedApplicant(; program=prog, rank=r*progapps[prog]÷100, offerdate=od, decidedate=dd, accept=prog=="CB" ? isodd(r) : iseven(r), program_history) for prog in ("CB", "NS"), r in 1:6, od in offerdates, dd in decidedates])
+        np = net_probability(σsels, σyields, σrs, σts; applicants, program_history, rmatch_floor=0)
+        @test np[:,1,:,:] ≈ np[:,2,:,:]
+        @test np[:,:,:,1] ≈ np[:,:,:,2]
+        @test !(np[1,:,:,:] ≈ np[2,:,:,:])
+        @test !(np[:,:,1,:] ≈ np[:,:,2,:])
+        idx = argmax(np)
+        @test idx[1] == idx[3] == 1
+    end
+
+    @testset "Wait list" begin
+        program_history = Dict{ProgramKey,ProgramData}()
+        for prog in ("CB", "NS"), yr in 2019:2021
+            program_history[ProgramKey(prog, yr)] = ProgramData(slots=10, napplicants=100, firstofferdate=Date("$yr-01-13"), lastdecisiondate=Date("$yr-04-15"))
+        end
+        # Top-ranked applicants decline late, lower-ranked applicants accept early
+        applicants = vec([NormalizedApplicant(; program=prog, rank=r, offerdate=Date("$yr-01-13"), decidedate=r>3 ? Date("$yr-01-15") : Date("$yr-04-15"), accept=r>3+(prog=="NS")-(yr==2019), program_history) for prog in ("CB", "NS"), r in 1:6, yr in 2019:2021])
+        past_applicants = filter(app -> app.season  < 2021, applicants)
+        test_applicants = filter(app -> app.season == 2021, applicants)
+        fmatch = match_function(; σr=0.0001f0)
+        actual_yield = Dict("CB" => 3, "NS" => 0)
+        nmatric, progstatus = wait_list_offers(fmatch, past_applicants, test_applicants, Date("2021-01-13"); program_history, actual_yield)
+        @test nmatric ≈ 6
+        @test progstatus["CB"].nmatriculants.val ≈ 3.5 && progstatus["CB"].nmatriculants.err ≈ 0.5
+        @test progstatus["NS"].nmatriculants.val ≈ 2.5 && progstatus["NS"].nmatriculants.err ≈ 0.5
+        @test progstatus["NS"].priority > progstatus["CB"].priority
+        @test progstatus["CB"].poutcome == 1
+        @test progstatus["NS"].poutcome == 0
+        # Just make sure this runs
+        nmatric, progstatus = wait_list_offers(fmatch, past_applicants, test_applicants, Date("2021-01-13"); program_history)
+        @test nmatric ≈ 6
+    end
 end


### PR DESCRIPTION
- add plotting of DBBS example
- clean up printing of DBBS example using DataFrames
- add functions to automatically tune the matching parameters (or at least, compute them)
- add ProgressMeter for long-running computations
- require that parameters generate a minimum number of matches for each applicant
- generate wait-list predictions with error bars
- optionally compute the p-value of actual outcomes