### PR TITLE
Simulate automated offers

### DIFF
--- a/examples/plot_outcomes.jl
+++ b/examples/plot_outcomes.jl
@@ -59,3 +59,23 @@ ax.set_ylabel("% of offers")
 ax.legend(lna, pnames; fontsize="x-small", bbox_to_anchor=(1,1))
 fig.tight_layout()
 fig.savefig("program_similarity_data.pdf")
+
+fig, axs = plt.subplots(1, 3; figsize=(7,3))
+ax = axs[1]
+ex = extrema(dbbsnmatric)
+ax.hist(dbbsnmatric; bins=ex[begin]:ex[end])
+ax.set_xlabel("# of matriculants")
+ax.set_ylabel("# of simulations")
+ax = axs[2]
+nex = sort(collect(nexhaust))
+ax.bar(0:length(nex)-1, 100*last.(nex)/length(dbbsnmatric))
+ax.set_xticks(0:length(nex)-1)
+ax.set_xticklabels(first.(nex); rotation="vertical")
+ax.set_ylabel("% of waitlist exhaustion")
+ax = axs[3]
+ax.bar(0:length(dates)-1, noffers / length(dbbsnmatric))
+ax.set_xticks(0:length(dates)-1)
+ax.set_xticklabels(dates; rotation="vertical")
+ax.set_ylabel("Mean # offers extended")
+fig.tight_layout()
+fig.savefig("outcome_waitlist_distribution.pdf")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -163,7 +163,7 @@ end
         test_applicants = filter(app -> app.season == 2021, applicants)
         fmatch = match_function(; σr=0.0001f0)
         actual_yield = Dict("CB" => 3, "NS" => 0)
-        nmatric, progstatus = wait_list_offers(fmatch, past_applicants, test_applicants, Date("2021-01-13"); program_history, actual_yield)
+        nmatric, progstatus = wait_list_analysis(fmatch, past_applicants, test_applicants, Date("2021-01-13"); program_history, actual_yield)
         @test nmatric ≈ 6
         @test progstatus["CB"].nmatriculants.val ≈ 3.5 && progstatus["CB"].nmatriculants.err ≈ 0.5
         @test progstatus["NS"].nmatriculants.val ≈ 2.5 && progstatus["NS"].nmatriculants.err ≈ 0.5
@@ -171,7 +171,7 @@ end
         @test progstatus["CB"].poutcome == 1
         @test progstatus["NS"].poutcome == 0
         # Just make sure this runs
-        nmatric, progstatus = wait_list_offers(fmatch, past_applicants, test_applicants, Date("2021-01-13"); program_history)
+        nmatric, progstatus = wait_list_analysis(fmatch, past_applicants, test_applicants, Date("2021-01-13"); program_history)
         @test nmatric ≈ 6
     end
 end


### PR DESCRIPTION
Simulate what would happen in a particular scenario with the code running the admissions season:
- Initial offers set so that each program had an 80% probability of not exceeding their target.
- Wait list offers extended on March 1, March 15, and April 1.  On each date, wait list offers are extended until the aggregate mean plus standard deviation exceeded the total DBBS target.
- While offers are extended in three boluses, program choice is made one offer at a time.  Compute the priority of each program for the "next" offer and choose the program with highest priority.  If that program has already exhausted its list of candidates who actually received offers during the 2021 season, move on to the next-most-deserving program.  Once an offer has been extended, repeat this process until the entire bolus of offers gets decided.
