### PR TITLE
Switch from loglike to correlation in training

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@
 /Manifest.toml
 /docs/build/
 /examples/*.csv
+/examples/*.xlsx
 /examples/*.pdf
 /examples/Manifest.toml

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -118,8 +118,8 @@ See [`match_function`](@ref) for specific details.
 
 How does one tune these parameters? The core idea is to train them based on past admissions seasons: if you have
 records extending back several years, you make matriculation predictions for year ``y`` based on data from all years up to
-and including year ``y-1``, and then compute a "net log likelihood" based on the actual outcome.
-See [`net_loglike`](@ref) for details.
+and including year ``y-1``, and then compute a correlation with the actual outcome.
+See [`match_correlation`](@ref) for details.
 
 ## Analysis and simulations
 

--- a/examples/parsedata.jl
+++ b/examples/parsedata.jl
@@ -88,4 +88,5 @@ for row in eachrow(df)
 end
 
 # Parse faculty data
-faculty_engagement = read_faculty_data("DBBS Formula 2021.csv")
+facrecs = read_faculty_data("DBBS Formula 2021.csv")
+facrecs = AdmissionsSimulation.aggregate(facrecs, AdmissionsSimulation.default_program_substitutions)

--- a/src/AdmissionsSimulation.jl
+++ b/src/AdmissionsSimulation.jl
@@ -15,7 +15,7 @@ export faculty_affiliations, program_service, calibrate_service, faculty_effort,
 # Program similarity
 export offerdata, yielddata, program_similarity, cached_similarity
 # Applicant similarity & matriculation
-export match_likelihood, match_function, matriculation_probability, run_simulation, select_applicant, net_loglike, wait_list_analysis
+export match_likelihood, match_function, matriculation_probability, run_simulation, select_applicant, match_correlation, wait_list_analysis
 # Low-level utilities
 export normdate, aggregate
 # I/O


### PR DESCRIPTION
Log-likelihood seemed to always give increasing value
for small sigma, suggesting that a few right answers with
high certainty were dominating the computation.
Switching to correlation yielded clearer "humps" in the computation.