### PR TITLE
Generate fake candidates to seed the season

### DIFF
--- a/src/AdmissionsSimulation.jl
+++ b/src/AdmissionsSimulation.jl
@@ -18,7 +18,7 @@ export offerdata, yielddata, program_similarity, cached_similarity
 # Applicant similarity & matriculation
 export match_likelihood, match_function, matriculation_probability, run_simulation, select_applicant, match_correlation, wait_list_analysis
 # Low-level utilities
-export normdate, aggregate
+export normdate, aggregate, generate_fake_candidates
 # I/O
 export read_program_history, read_applicant_data, read_faculty_data
 

--- a/src/predict.jl
+++ b/src/predict.jl
@@ -132,7 +132,7 @@ function add_offers!(fmatch::Function,
                      program_history)
     function calc_pmatric(applicant, pd = program_history[ProgramKey(applicant)])
         ntnow = normdate(tnow, pd)
-        applicant.normdecidedate <= ntnow && return Float32(applicant.accept)
+        applicant.normdecidedate !== missing && applicant.normdecidedate <= ntnow && return Float32(applicant.accept)
         like = match_likelihood(fmatch, past_applicants, applicant, ntnow)
         return matriculation_probability(like, past_applicants)
     end
@@ -186,6 +186,8 @@ end
     program_offers = initial_offers!(fmatch, program_candidates::Dict, past_applicants, tnow::Date=today(), σthresh=2; program_history)
 
 Allocate initial offers of admission at the beginning of the season.  See [`add_offers!`](@ref) for more information.
+See also [`generate_fake_candidates`](@ref) to plan offers in cases where some programs want to make their initial offers
+before other programs have finished interviewing.
 """
 function initial_offers!(fmatch::Function, program_candidates::Dict, args...; kwargs...)
     program_offers = Dict(program => NormalizedApplicant[] for program in keys(program_candidates))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -341,6 +341,14 @@ end
         @test length(program_offers["CB"]) == 6
         @test length(program_candidates["NS"]) == 0
         @test length(program_candidates["CB"]) == 1
+        # Using random applicants. This is useful for setting the initial number of accepts.
+        # The following test assumes σt = Inf (as it is above)
+        fake_candidates1 = generate_fake_candidates(program_history, 2021)
+        fake_offers1 = initial_offers!(fmatch, fake_candidates1, past_applicants, Date("2021-01-01"); program_history)
+        fake_candidates2 = generate_fake_candidates(program_history, 2021, Dict("CB" => Date.(["2021-01-13", "2021-02-02"])))
+        fake_offers2 = initial_offers!(fmatch, fake_candidates2, past_applicants, Date("2021-01-01"); program_history)
+        dictcount(d) = Dict(key=>length(val) for (key,val) in d)
+        @test dictcount(fake_offers1) == dictcount(fake_offers2)
 
         ## Analyzing wait list
         applicants = vec([NormalizedApplicant(; program=prog, rank=r, offerdate=Date("$yr-01-13"), decidedate=r>3 ? Date("$yr-01-15") : Date("$yr-04-15"), accept=r>3+(prog=="NS")-(yr==2019), program_history) for prog in ("CB", "NS"), r in 1:6, yr in 2019:2021])


### PR DESCRIPTION
This is useful to decide the number of initial offers/program before
interview scores are available for all programs.