### PR TITLE
Explore slots with tweaks

### DIFF
--- a/examples/DBBStargets_floor_proposal.jl
+++ b/examples/DBBStargets_floor_proposal.jl
@@ -1,0 +1,61 @@
+# How would 2021 have worked out if we were to:
+# - compute faculty effort for new programs (BIDS & CB) by regression against applicants
+# - reserve 2 slots for PMB (Danforth agreement)
+# - use a hyperbolic floor with minslots=4
+
+include("parsedata.jl")
+using GLM
+
+this_season = 2021
+effort_end_date = Date("2021-06-23")   # date on which effort table was generated
+regressprogs = ["BIDS", "CB"]    # programs that get their slots set manually
+addprogs = Dict("PMB"=>2)              # programs that get an additive bonus
+minfloor = 4
+
+daterange = effort_end_date-Year(5):Day(1):effort_end_date
+facs, progs, E = faculty_effort(facrecs, daterange)
+fs = faculty_involvement(E)
+program_nfaculty = Dict(zip(progs, fs))
+program_napplicants = Dict(pk.program=>pd.napplicants for (pk, pd) in program_history if pk.season == this_season)
+nslots0 = sum(pd.target_corrected for (pk, pd) in program_history if pk.season == this_season)
+
+# Perform the regression to adjust faculty effort
+nf = [program_nfaculty[prog] for prog in pnames if prog ∉ regressprogs]
+na = [program_napplicants[prog] for prog in pnames if prog ∉ regressprogs]
+lbls = [prog for prog in pnames if prog ∉ regressprogs]
+model = glm(reshape(Float32.(na), :, 1), nf, Normal(), IdentityLink())
+preds = predict(model, reshape(Float32[program_napplicants[prog] for prog in regressprogs], :, 1))
+for (prog, pred) in zip(regressprogs, preds)
+    program_nfaculty[prog] = pred
+end
+# Compute the remaining slots
+nslots = nslots0
+for (_, n) in addprogs
+    global nslots
+    nslots -= n
+end
+# Assign slots with a floor
+tgts, p = targets(program_napplicants, program_nfaculty, nslots, minfloor)
+# Apply adds
+for (prog, n) in addprogs
+    tgts[prog] += n
+end
+@assert sum(values(tgts)) ≈ nslots0
+
+dftweaks = DataFrame("" => String[], [name=>Float32[] for name in pnames]...)
+push!(dftweaks, ["Tweaked"; [round(tgts[prog]; digits=1) for prog in pnames]])
+push!(dftweaks, ["Actual"; [program_history[ProgramKey(prog, this_season)].target_corrected for prog in pnames]])
+
+# using PyPlot: PyPlot, plt
+# fig, ax = plt.subplots()
+# ax.scatter(na, nf)
+# for (a, f, lbl) in zip(na, nf, lbls)
+#     ax.text(a, f, lbl)
+# end
+# xl, yl = ax.get_xlim(), ax.get_ylim()
+# ax.set_xlim((0, xl[2]))
+# ax.set_ylim((0, yl[2]))
+# ax.set_xlabel("# applicants")
+# ax.set_ylabel("# faculty (NormEffort)")
+# fig.tight_layout()
+# fig.savefig("applicants_faculty_regression.pdf")

--- a/examples/Project.toml
+++ b/examples/Project.toml
@@ -2,6 +2,7 @@
 AdmissionsSimulation = "e9cde6de-6074-429b-acec-d279973730fc"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+GLM = "38e38edf-8417-5370-95a0-9cbb8c7f171a"
 InvertedIndices = "41ab1584-1d38-5bbf-9106-f11c6c58b48f"
 LatexPrint = "d2208f48-c256-5759-9089-c25ed2a93924"
 MultivariateStats = "6f286f6a-111f-5878-ab1e-185364afe411"

--- a/examples/export_dataframes.jl
+++ b/examples/export_dataframes.jl
@@ -37,3 +37,9 @@ if isdefined(Main, :final_class)
         tabular(io, final_class)
     end
 end
+
+if isdefined(Main, :dftweaks)
+    open("tweaked_slots.tex", "w") do io
+        tabular(io, dftweaks)
+    end
+end

--- a/src/targets.jl
+++ b/src/targets.jl
@@ -143,9 +143,11 @@ function faculty_effort(facrecs::ListPairs{String,FacultyRecord},
     for (key, facrec) in facrecs
         j = faclkup[key]
         daysfac = intersect(facrec.start:Day(1):finaldate, dayrange)
+        isempty(daysfac) && !isempty(facrec.service) && @warn("$key has service but date range is empty (setting to 1 year)")
         for (prog, fi) in facrec.service
             thisprogdays = intersect(daysfac, progdays[prog])
-            E[j, proglkup[prog]] += (sc === nothing ? total(fi) : total(fi, sc)) / (length(thisprogdays)/365)
+            nyrs = isempty(daysfac) ? 1.0 : length(thisprogdays)/365
+            E[j, proglkup[prog]] += (sc === nothing ? total(fi) : total(fi, sc)) / nyrs
         end
     end
     return ufacs, uprogs, E


### PR DESCRIPTION
This examines how 2021 would have worked out had we applied
the following tweaks:
- compute BIDS & CB by linear regression of fᵢ vs aᵢ
- reserve 2 slots for PMB (Danforth agreement)
- use a hyperbolic floor with minslots=4

This is essentially a way to try out this same scheme for 2022.