### PR TITLE
Fix test failures due to dates

### DIFF
--- a/src/targets.jl
+++ b/src/targets.jl
@@ -134,7 +134,6 @@ function faculty_effort(facrecs::ListPairs{String,FacultyRecord},
     uprogs, ufacs = sort(collect(uprogs)), sort(collect(ufacs))
     proglkup = Dict(zip(uprogs, 1:length(uprogs)))
     faclkup = Dict(zip(ufacs, 1:length(ufacs)))
-    ndays = eltype(daterange) === Date ? length(daterange) : length(daterange) * 365
     thisyear = year(finaldate)
     dayrange = eltype(daterange) === Date ? daterange : (Date(minimum(daterange), 1, 1):Day(1):Date(min(thisyear, maximum(daterange)), 12, 31))
     progdays = Dict(name => Date(minimum(yrrng), 1, 1):Day(1):Date(min(thisyear, maximum(yrrng)), 12, 31) for (name, yrrng) in progyears)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -62,14 +62,14 @@ end
         @test progsvc["BIDS"] == Service(5, 0)
         @test progsvc["BBSB"] == Service(0, 3)
         @test progsvc["HSG"] == Service(11, 1)
-        sc = calibrate_service(progsvc)
-        @test sc == calibrate_service(facrecords)
+        sc = calibrate_service(progsvc, 2019)
+        @test sc == calibrate_service(facrecords, 2019)
         @test sc.c_per_i ≈ 1/11
         @test AdmissionsSimulation.total(Service(1, 0), sc)  ≈ 11.1/11
         @test AdmissionsSimulation.total(Service(0, 1), sc)  ≈ 11.1
         @test AdmissionsSimulation.total(Service(11, 1), sc) ≈ 11.1       # we use max over interview and committees
         @test AdmissionsSimulation.total(Service(12, 1), sc) ≈ 12/11 * 11.1
-        facs, progs, E = faculty_effort(facrecords, 2021:2021; sc)
+        facs, progs, E = faculty_effort(facrecords, Date("2021-01-01"):Day(1):Date("2021-05-31"); sc)
         fiis = Dict(zip(progs, faculty_involvement(E; scheme=:thresheffort)))
         @test fiis["BBSB"] == 3
         @test fiis["BIDS"] == 2


### PR DESCRIPTION
Specifying time ranges is key to making sure that these
tests don't change in their results.