### PR TITLE
Drop students who withdraw during parsing

### DIFF
--- a/AdmissionTargets/test/runtests.jl
+++ b/AdmissionTargets/test/runtests.jl
@@ -3,11 +3,14 @@
 # See the AdmissionSuite/.github/workflows/CI.yml file for the needed configuration steps
 
 using AdmissionTargets
+using AdmitConfiguration
 using Dates
 using Test
 
 @testset "AdmissionTargets.jl" begin
     @testset "Targets" begin
+        dfmt = AdmitConfiguration.date_fmt[]
+        AdmitConfiguration.date_fmt[] = DateFormat("mm/dd/yyyy")
         # Test the "don't game the system" ethic
         program_applicants = Dict("ATMP" => 10, "BTMP" => 10, "CTMP" => 10)
         fiis = Dict("ATMP" => 2, "BTMP" => 2, "CTMP" => 2)
@@ -163,5 +166,6 @@ using Test
         @test tgts["ProgA"] ≈ 4
         @test tgts["ProgB"] ≈ 6
         @test_logs (:warn, "The following programs 'earned' less than one slot (give them notice): [\"ProgA\"]") targets(Dict("ProgA"=>1, "ProgB"=>11), nothing, 11, 2)
+        AdmitConfiguration.date_fmt[] = dfmt
     end
 end

--- a/Admit/Project.toml
+++ b/Admit/Project.toml
@@ -15,9 +15,9 @@ DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 Measurements = "eff96d63-e80a-5855-80a2-b1b0885c5ab7"
 NLsolve = "2774e3e8-f4cf-5e23-947b-6d7e65073b56"
 ODBC = "be6f12e9-ca4f-5eb2-a339-a4f995cc0291"
+PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
-SnoopPrecompile = "66db9d55-30c0-4569-8b51-7e840670fc0c"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
@@ -30,8 +30,8 @@ DocStringExtensions = "0.8"
 Measurements = "2"
 NLsolve = "4"
 ODBC = "1"
+PrecompileTools = "1"
 ProgressMeter = "1"
-SnoopPrecompile = "1"
 julia = "1.6"
 
 [extras]

--- a/Admit/src/Admit.jl
+++ b/Admit/src/Admit.jl
@@ -34,9 +34,9 @@ include("io.jl")
 include("sql.jl")
 include("web.jl")
 
-using SnoopPrecompile
+using PrecompileTools
 
-@precompile_setup begin
+@setup_workload begin
     struct FakeConn
         applicants::DataFrame
         programs::DataFrame
@@ -92,7 +92,7 @@ using SnoopPrecompile
                            "accept" => [[true, false, true, false, true, false, true, false]; fill(missing, 8)])
     conn = FakeConn(applicants, programs)
 
-    @precompile_all_calls begin
+    @compile_workload begin
         parse_database(conn)
         # runweb(conn; tnow=Date(2023, 3, 1))  # this would be nice, but clean shutdown is difficult
     end

--- a/Admit/test/fakedb.jl
+++ b/Admit/test/fakedb.jl
@@ -21,6 +21,8 @@ DBInterface.execute(conn::FakeConn, tablename::String) =
 
     # Save column_configuration and sql_queries before we modify them
     cc = copy(Admit.AdmitConfiguration.column_configuration)
+    dfmt = AdmitConfiguration.date_fmt[]
+    AdmitConfiguration.date_fmt[] = DateFormat("mm/dd/yyyy")
     Admit.AdmitConfiguration.column_configuration["napplicants"] = "napp"
     Admit.AdmitConfiguration.column_configuration["nmatriculants"] = "nmatric"
     sqlq = copy(Admit.AdmitConfiguration.sql_queries)
@@ -40,12 +42,12 @@ DBInterface.execute(conn::FakeConn, tablename::String) =
         end
 
         getapplicant(apps, name) = apps[findfirst(app->app.name==name, apps)]
-        @test length(applicants) == 8
-        for (name, prog, nod, accept, dd) in zip(("Last1, First1", "Last2, First2", "Last3, First3", "Last4, First4"),
-                                                ("MGG", "MMMP", "NS", "PMB"),
-                                                (missing, 0.0f0, 0.0f0, missing),
-                                                (missing, false, true, missing),
-                                                (missing, Date(2021, 3, 3), Date(2021, 4, 1), missing))
+        @test length(applicants) == 4
+        for (name, prog, nod, accept, dd) in zip(("Last2, First2", "Last3, First3"),
+                                                ("MMMP", "NS"),
+                                                (0.0f0, 0.0f0),
+                                                (false, true),
+                                                (Date(2021, 3, 3), Date(2021, 4, 1)))
             app = applicants[findfirst(app->app.applicantdata.name==name, applicants)]
             @test app.program == prog
             @test app.season == 2021
@@ -70,5 +72,6 @@ DBInterface.execute(conn::FakeConn, tablename::String) =
         merge!(Admit.AdmitConfiguration.column_configuration, cc)
         empty!(Admit.AdmitConfiguration.sql_queries)
         merge!(Admit.AdmitConfiguration.sql_queries, sqlq)
+        AdmitConfiguration.date_fmt[] = dfmt
     end
 end

--- a/AdmitConfiguration/examples/fake_configure_WashU.jl
+++ b/AdmitConfiguration/examples/fake_configure_WashU.jl
@@ -20,3 +20,4 @@ set_column_configuration(# Applicant table
                          "napplicants" => "Total Applicants",
                          # nmatriculants not present
 )
+set_date_format("y-m-d H:M:S.s")

--- a/AdmitConfiguration/examples/local_functions_WashU.jl
+++ b/AdmitConfiguration/examples/local_functions_WashU.jl
@@ -14,7 +14,17 @@ function getdecidedate(row)
     if acc === true
         return todate_or_missing(row."Class Member Date")
     elseif acc === false
-        return todate_or_missing(row."Declined Date")
+        rawdate = row."Declined Date"
+        # In real applications we know these columns exist (the `hasproperty` checks always return `true`),
+        # but the WashU config is also used for testing and some of the fake data sets don't set these columns.
+        # For your own institution, you probably don't need the `hasproperty` checks.
+        if (ismissing(rawdate) || isempty(rawdate)) && hasproperty(row, "Interviewed, Reject Date")
+            rawdate = row."Interviewed, Reject Date"
+        end
+        if (ismissing(rawdate) || isempty(rawdate)) && hasproperty(row, "Withdrew Following Interview Date")
+            rawdate = row."Withdrew Following Interview Date"
+        end
+        return todate_or_missing(rawdate)
     end
     return missing
 end

--- a/AdmitConfiguration/src/AdmitConfiguration.jl
+++ b/AdmitConfiguration/src/AdmitConfiguration.jl
@@ -28,7 +28,7 @@ const program_range = Dict{String,UnitRange{Int}}()
 const program_substitutions = Dict{String,Vector{String}}()
 const sql_dsn = Ref{String}()
 const sql_queries = Dict{String,String}()
-const date_fmt = Ref{DateFormat}(DateFormat(@load_preference("date_format", "mm/dd/yyyy")))
+const date_fmt = Ref{DateFormat}(DateFormat("mm/dd/yyyy"))
 const local_functions = Ref{Union{String,Nothing}}()
 const column_configuration = Dict{String,String}()
 
@@ -139,9 +139,9 @@ Applicant table columns:
 - "rank" (optional): the applicant rank assigned by the admissions committee/interviewers. From highest (top-rated) to lowest,
   they should be numbered 1, 2, 3, ... Each program should have separate ranking.
 - "accept" (optional): `true`/`false`/`missing` indicating whether the applicant accepted the offer of admission.
-  The alternative to setting this column is [`set_local_functions`](@ref).
+  The alternative to setting this column is [`set_local_functions`](@ref), but "accept" takes precedence.
 - "decide date" (optional): the date of the applicant's decision.
-  The alternative to setting this column is [`set_local_functions`](@ref).
+  The alternative to setting this column is [`set_local_functions`](@ref), but "decide date" takes precedence.
 
 Program table columns:
 
@@ -208,6 +208,10 @@ function loadprefs()
         end
     end
 
+    dfmt = @load_preference("date_format")
+    if dfmt !== nothing
+        date_fmt[] = DateFormat(dfmt)
+    end
     plook = @load_preference("program_lookups")
     plook !== nothing && merge!(program_lookups, plook)
     pabv = @load_preference("program_abbreviations")

--- a/AdmitConfiguration/src/local_function_stubs.jl
+++ b/AdmitConfiguration/src/local_function_stubs.jl
@@ -5,8 +5,13 @@
 """
     getaccept(row)
 
-Return `true` or `false` depending on whether the applicant in `row` (a row of the applicant table)
-accepted the offer of admission.
+Return
+    - `true` if the applicant has accepted an offer of admission
+    - `false` if the applicant is no longer a candidate for admission
+    - `missing` if the applicant is a candidate but the decision is unknown
+
+A `getaccept` function can be omitted if your database has a column containing this information
+(see [`set_column_configuration`](@ref) for `"accept"`).
 
 # Example
 
@@ -17,15 +22,28 @@ or "Withdrew". Then in simplest form you could implement this function as:
 getaccept(row) = row."Outcome" == "Accept"
 ```
 
-More sophisticated implementations might check for unexpected values and throw an error if they are encountered.
+A better implementation might allow the "Outcome" field to be blank, returning `missing` in that case:
+
+```julia
+function getaccept(row)
+    outcome = row."Outcome"
+    (ismissing(outcome) || isempty(outcome)) && return missing
+    return outcome == "Accept"
+end
+```
+
+Even more sophisticated implementations might check for unexpected values and throw an error if they are encountered.
 """
 function getaccept end
 
 """
     getdecidedate(row)
 
-Return the date on which the applicant in `row`  (a row of the applicant table) informed admissions
-about their decision about whether to accept the offer of admission.
+Return the date on which the verdict for the applicant in `row` (a row of the applicant table) was determined.
+This might be the date where they either accepted an offer, were rejected, or withdrew their application.
+
+A `getdecidedate` function can be omitted if your database has a column containing this information
+(see [`set_column_configuration`](@ref) for `"decide date"`).
 
 # Example
 


### PR DESCRIPTION
This changes several test outcomes

Also:

- switch to PrecompileTools
- put configuration of date format into example config
- make date config runtime rather than compiletime