### PR TITLE
Support program synonyms

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,12 +20,12 @@ jobs:
         arch:
           - x64
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         env:
           cache-name: cache-artifacts
         with:
@@ -48,6 +48,6 @@ jobs:
       - uses: julia-actions/julia-processcoverage@v1
         with:
           directories: AdmitConfiguration/src,Admit/src,AdmissionTargets/src
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v5
         with:
           file: lcov.info

--- a/AdmissionTargets/test/runtests.jl
+++ b/AdmissionTargets/test/runtests.jl
@@ -10,6 +10,8 @@ using Test
 @testset "AdmissionTargets.jl" begin
     @testset "Targets" begin
         dfmt = AdmitConfiguration.date_fmt[]
+        psbst = deepcopy(AdmissionTargets.program_substitutions)
+        delete!(AdmissionTargets.program_substitutions, "HSG")
         AdmitConfiguration.date_fmt[] = DateFormat("mm/dd/yyyy")
         # Test the "don't game the system" ethic
         program_applicants = Dict("ATMP" => 10, "BTMP" => 10, "CTMP" => 10)
@@ -167,5 +169,7 @@ using Test
         @test tgts["ProgB"] ≈ 6
         @test_logs (:warn, "The following programs 'earned' less than one slot (give them notice): [\"ProgA\"]") targets(Dict("ProgA"=>1, "ProgB"=>11), nothing, 11, 2)
         AdmitConfiguration.date_fmt[] = dfmt
+        empty!(AdmissionTargets.program_substitutions)
+        merge!(AdmissionTargets.program_substitutions, psbst)
     end
 end

--- a/Admit/src/utils.jl
+++ b/Admit/src/utils.jl
@@ -108,6 +108,19 @@ function accum!(ph, pk, pd)
     return ph
 end
 
+function build_program_synonyms(progs)
+    progsubst = Dict(prog => [prog] for prog in progs)
+    for (old, news) in program_substitutions
+        for n in news
+            while !haskey(progsubst, n)
+                n = only(program_substitutions[n])
+            end
+            push!(progsubst[n], old)
+        end
+    end
+    return progsubst
+end
+
 """
     program_candidates = generate_fake_candidates(program_history, season::Integer, program_offer_dates=nothing)
 

--- a/Admit/src/web.jl
+++ b/Admit/src/web.jl
@@ -83,6 +83,7 @@ function manage_offers(fetch_past_applicants::Function, fetch_applicants::Functi
 
     applicants = Ref(fetch_applicants())
     progs = sort(unique(pk.program for (pk, _) in program_history if pk.season == season(get_tnow(tnow))))
+    probsubst = build_program_synonyms(progs)
     target = compute_target(program_history, _season)
 
     target_input = dcc_input(id="total-target", value=compute_target(program_history, season(get_tnow(tnow))), type="number")
@@ -128,11 +129,11 @@ function manage_offers(fetch_past_applicants::Function, fetch_applicants::Functi
             target = tgt
             return render_tab_summary(fmatch, past_applicants, applicants[], get_tnow(tnow), program_history, target, σthresh)
         elseif active_tab == "tab-program"
-            return render_program_zoom(fmatch, past_applicants, filter(app->app.program==prog, applicants[]), get_tnow(tnow), program_history[ProgramKey(prog, _season)], prog)
+            return render_program_zoom(fmatch, past_applicants, filter(app->app.program∈progsubst[prog], applicants[]), get_tnow(tnow), program_history[ProgramKey(prog, _season)], progsubst[prog])
         elseif active_tab == "tab-initial"
             return render_tab_initial(fmatch, past_applicants, applicants[], Date(_season), program_history, target, σthresh)
         elseif active_tab == "tab-internals"
-            return render_internals(fmatch, past_applicants, applicants[], get_tnow(tnow), program_history, progsim, progs)
+            return render_internals(fmatch, past_applicants, applicants[], get_tnow(tnow), program_history, progsim, progs, progsubst)
         else
             return html_p("An unexpected tab error occurred, please report how to trigger this error")
         end
@@ -213,7 +214,7 @@ function render_program_zoom(fmatch::Function,
                              applicants::AbstractVector{NormalizedApplicant},
                              tnow::Date,
                              pd::ProgramData,
-                             prog::AbstractString)
+                             prog::AbstractVector{<:AbstractString})
     function calc_pmatric(applicant)  # TODO? copied from add_offers!, would be better not to copy but it's a closure...
         ndd = applicant.normdecidedate
         ndd !== missing && ndd <= ntnow && return Float32(applicant.accept::Bool)
@@ -248,7 +249,7 @@ function render_program_zoom(fmatch::Function,
     seasonrange = (typemax(Int), typemin(Int))
     update_range((_min, _max), x) = (min(_min, x), max(_max, x))
     for app in past_applicants
-        app.program == prog || continue
+        app.program ∈ prog || continue
         ndd = app.normdecidedate
         isa(ndd, Real) || continue
         if app.accept === true
@@ -351,7 +352,8 @@ function render_internals(fmatch::Function,
                           tnow::Date,
                           program_history,
                           progsim::Function,
-                          progs::AbstractVector{<:AbstractString})
+                          progs::AbstractVector{<:AbstractString},
+                          progsubst::AbstractDict{String})
     _season = season(tnow)
     psim = [[progsim(px, py) for px in progs] for py in progs]
     nmatches = Dict{String,Measurement{Float64}}()
@@ -360,7 +362,7 @@ function render_internals(fmatch::Function,
         ntnow = normdate(tnow, program_history[ProgramKey(program=prog, season=_season)])
         for app in applicants
             ndd = app.normdecidedate
-            app.program == prog && (ismissing(ndd) || ndd > ntnow) || continue
+            app.program ∈ progsubst[prog] && (ismissing(ndd) || ndd > ntnow) || continue
             push!(nsim, sum(pastapp->fmatch(app, pastapp, ntnow), past_applicants))
         end
         nmatches[prog] = round(mean(nsim); digits=1) ± round(std(nsim); digits=1)

--- a/Admit/test/data/sql_applicant_table.csv
+++ b/Admit/test/data/sql_applicant_table.csv
@@ -1,4 +1,4 @@
-enrollment_year,program_interest,Applicant,Interview Date,"Current/Final Stage","Interviewed, Hold","Interviewed, High Hold",Acceptance Offered Date,Class Member Date,Declined Date,Deferred,"Interviewed, Reject",Withdrew Following Interview
+enrollment_year,program_interest,Applicant,Interview Date,"Final Outcome","Interviewed, Hold","Interviewed, High Hold",Acceptance Offered Date,Class Member,Declined,Deferred,"Interviewed, Reject",Withdrew Following Interview
 2021,Molecular Genetics and Genomics,"Last1, First1",01/04/2021,Withdrew Following Interview,02/10/2021,,,,,,,03/17/2021
 2021,Molecular Microbiology and Microbial Pathogenesis,"Last2, First2",01/29/2021,Declined,,,02/03/2021,,03/03/2021,,,
 2021,Neurosciences,"Last3, First3",02/05/2021,Class Member,,,02/10/2021,04/01/2021,,,,

--- a/Admit/test/data/sql_applicant_table_with_duplicates.csv
+++ b/Admit/test/data/sql_applicant_table_with_duplicates.csv
@@ -1,4 +1,4 @@
-enrollment_year,program_interest,Applicant,Stage Date,Interview Date,"Current/Final Stage","Interviewed, Hold","Interviewed, High Hold",Acceptance Offered Date,Class Member Date,Declined Date,Deferred,"Interviewed, Reject",Withdrew Following Interview
+enrollment_year,program_interest,Applicant,Stage Date,Interview Date,"Final Outcome","Interviewed, Hold","Interviewed, High Hold",Acceptance Offered Date,Class Member,Declined,Deferred,"Interviewed, Reject",Withdrew Following Interview
 2020,Molecular Genetics and Genomics,"Last1a, First1",,01/04/2020,Withdrew Following Interview,02/10/2020,,,,,,,03/17/2020
 2020,Molecular Microbiology and Microbial Pathogenesis,"Last2a, First2",,01/29/2020,Declined,,,02/03/2020,,03/03/2020,,,
 2020,Neurosciences,"Last3a, First3",2020-04-01T10:08:22,02/05/2020,Class Member,,,02/10/2020,04/01/2020,,,,

--- a/Admit/test/fakedb.jl
+++ b/Admit/test/fakedb.jl
@@ -1,4 +1,5 @@
 using Admit
+using AdmitConfiguration
 using Admit.CSV
 using DataFrames
 using DBInterface

--- a/Admit/test/runtests.jl
+++ b/Admit/test/runtests.jl
@@ -3,6 +3,7 @@
 # See the AdmissionSuite/.github/workflows/CI.yml file for the needed configuration steps
 
 using Admit
+using AdmitConfiguration
 using Dates
 using CSV
 using DataFrames
@@ -390,7 +391,7 @@ end
 
     @testset "Web" begin
         # We don't test that it renders, but we do check all the callbacks
-        progs = ["BBSB","BIDS","CB","CSB","DRSCB","EEPB","HSG","IMM","MCB","MGG","MMMP","NS","PMB"]
+        progs = ["BBSB","BIDS","CB","CSB","DRSCB","EEB","IMM","MCB","MGG","MMMP","NS","PMB"]
         yrs = 2017:2022
         program_history = Dict{ProgramKey,ProgramData}()
         for yr in yrs, prog in progs
@@ -425,13 +426,14 @@ end
             past_applicants, applicants, fixeddate, program_history, target, 2)
         @test isa(tab, Admit.DashBase.Component)
         prog = "MMMP"
+        progsubst = Admit.build_program_synonyms(progs)
         tab = Admit.render_program_zoom(fmatch, past_applicants,
-            filter(app->app.program==prog, applicants), fixeddate, program_history[ProgramKey(prog,last(yrs))], prog)
+            filter(app->app.program==prog, applicants), fixeddate, program_history[ProgramKey(prog,last(yrs))], progsubst[prog])
         @test isa(tab, Admit.DashBase.Component)
         tab = Admit.render_tab_initial(fmatch,
             past_applicants, applicants, fixeddate, program_history, target, 2)
         @test isa(tab, Admit.DashBase.Component)
-        tab = Admit.render_internals(fmatch, past_applicants, applicants, fixeddate, program_history, Admit.default_similarity, progs)
+        tab = Admit.render_internals(fmatch, past_applicants, applicants, fixeddate, program_history, Admit.default_similarity, progs, progsubst)
         @test isa(tab, Admit.DashBase.Component)
     end
 end

--- a/AdmitConfiguration/examples/local_functions_WashU.jl
+++ b/AdmitConfiguration/examples/local_functions_WashU.jl
@@ -1,4 +1,4 @@
-getaccept(row) = getaccept(row."Current/Final Stage")
+getaccept(row) = getaccept(row."Final Outcome")
 getaccept(::Missing) = missing
 function getaccept(choice::AbstractString)
     if choice ∈ ("Class Member", "Deferred")
@@ -12,17 +12,18 @@ end
 function getdecidedate(row)
     acc = getaccept(row)
     if acc === true
-        return todate_or_missing(row."Class Member Date")
+        # return todate_or_missing(row."Class Member Date")
+        return todate_or_missing(row."Class Member")
     elseif acc === false
-        rawdate = row."Declined Date"
+        rawdate = row."Declined"
         # In real applications we know these columns exist (the `hasproperty` checks always return `true`),
         # but the WashU config is also used for testing and some of the fake data sets don't set these columns.
         # For your own institution, you probably don't need the `hasproperty` checks.
-        if (ismissing(rawdate) || isempty(rawdate)) && hasproperty(row, "Interviewed, Reject Date")
-            rawdate = row."Interviewed, Reject Date"
+        if (ismissing(rawdate) || isempty(rawdate)) && hasproperty(row, "Interviewed, Reject")
+            rawdate = row."Interviewed, Reject"
         end
-        if (ismissing(rawdate) || isempty(rawdate)) && hasproperty(row, "Withdrew Following Interview Date")
-            rawdate = row."Withdrew Following Interview Date"
+        if (ismissing(rawdate) || isempty(rawdate)) && hasproperty(row, "Withdrew Following Interview")
+            rawdate = row."Withdrew Following Interview"
         end
         return todate_or_missing(rawdate)
     end


### PR DESCRIPTION
For programs that change names, be sure we include past applications who
applied under the old name(s).